### PR TITLE
remove reference to num_classes in get_test_input

### DIFF
--- a/detect.py
+++ b/detect.py
@@ -39,7 +39,7 @@ def get_test_input(input_dim, CUDA):
     
     if CUDA:
         img_ = img_.cuda()
-    num_classes
+    
     return img_
 
 


### PR DESCRIPTION
This might be the most trivial pull request ever as it not impacting the execution of the code. However, when deconstructing the code to understand it this line caused a problem due to it being considered "not defined" within the scope of the get_test_input function. It doesn't appear to serve a purpose anymore.