### PR TITLE
simplify create_modules() 'route' option

### DIFF
--- a/darknet.py
+++ b/darknet.py
@@ -206,36 +206,12 @@ def create_modules(blocks):
         
         #If it is a route layer
         elif (x["type"] == "route"):
-            x["layers"] = x["layers"].split(',')
-            
-            #Start  of a route
-            start = int(x["layers"][0])
-            
-            #end, if there exists one.
-            try:
-                end = int(x["layers"][1])
-            except:
-                end = 0
-                
-            
-            
-            #Positive anotation
-            if start > 0: 
-                start = start - index
-            
-            if end > 0:
-                end = end - index
 
             
             route = EmptyLayer()
             module.add_module("route_{0}".format(index), route)
             
-            
-            
-            if end < 0:
-                filters = output_filters[index + start] + output_filters[index + end]
-            else:
-                filters= output_filters[index + start]
+            filters = sum([output_filters[int(i)] for i in x['layers'].split(',')])
                         
             
         


### PR DESCRIPTION
Thanks a million for your blogs! Im currently going through the entire setup and loving it :D
I thought I'd give back a bit by (starting with) this simplification.
Correct me if I'm wrong, but I think all you are trying to achieve is to sum the number of output filters for the 1 or 2 layers a route-layer is referring to. This can be done in 1 line as proposed.

I'm not a 100% sure if Redmon is using 0 indexing when referring to his layers, but I believe he is.