### PR TITLE
Fix a bug on Windows  when saving an output img.

### DIFF
--- a/cam_demo.py
+++ b/cam_demo.py
@@ -116,7 +116,7 @@ if __name__ == '__main__':
             
             img, orig_im, dim = prep_image(frame, inp_dim)
             
-#            im_dim = torch.FloatTensor(dim).repeat(1,2)                        
+            im_dim = torch.FloatTensor(dim).repeat(1,2)                        
             
             
             if CUDA:

--- a/detect.py
+++ b/detect.py
@@ -15,6 +15,8 @@ import pandas as pd
 import random 
 import pickle as pkl
 import itertools
+import platform
+
 
 class test_net(nn.Module):
     def __init__(self, num_layers, input_size):
@@ -298,8 +300,11 @@ if __name__ ==  '__main__':
     
             
     list(map(lambda x: write(x, im_batches, orig_ims), output))
-      
-    det_names = pd.Series(imlist).apply(lambda x: "{}/det_{}".format(args.det,x.split("/")[-1]))
+    
+    if platform.system() == 'Windows':
+        det_names = pd.Series(imlist).apply(lambda x: "{}\\det_{}".format(args.det,x.split("\\")[-1]))
+    else:
+        det_names = pd.Series(imlist).apply(lambda x: "{}/det_{}".format(args.det,x.split("/")[-1]))
     
     list(map(cv2.imwrite, det_names, orig_ims))
     


### PR DESCRIPTION
The separator in Windows is "\\" and in Linux is "/", so this line will be invalid on Win system
```
det_names = pd.Series(imlist).apply(lambda x: "{}/det_{}".format(args.det,x.split("/")[-1]))
```
and I modified it to
```
if platform.system() == 'Windows':
        det_names = pd.Series(imlist).apply(lambda x: "{}\\det_{}".format(args.det,x.split("\\")[-1]))
    else:
        det_names = pd.Series(imlist).apply(lambda x: "{}/det_{}".format(args.det,x.split("/")[-1]))
```